### PR TITLE
support -ssl_insecure flag as mitmproxy does

### DIFF
--- a/cmd/go-mitmproxy/main.go
+++ b/cmd/go-mitmproxy/main.go
@@ -19,6 +19,7 @@ type Config struct {
 
 	addr    string
 	webAddr string
+	ssl_insecure bool
 
 	dump      string // dump filename
 	dumpLevel int    // dump level
@@ -32,6 +33,7 @@ func loadConfig() *Config {
 	flag.BoolVar(&config.version, "version", false, "show version")
 	flag.StringVar(&config.addr, "addr", ":9080", "proxy listen addr")
 	flag.StringVar(&config.webAddr, "web_addr", ":9081", "web interface listen addr")
+	flag.BoolVar(&config.ssl_insecure, "ssl_insecure", false, "not verify upstream server SSL/TLS certificates.")
 	flag.StringVar(&config.dump, "dump", "", "dump filename")
 	flag.IntVar(&config.dumpLevel, "dump_level", 0, "dump level: 0 - header, 1 - header + body")
 	flag.StringVar(&config.mapperDir, "mapper_dir", "", "mapper files dirpath")
@@ -60,6 +62,7 @@ func main() {
 	opts := &proxy.Options{
 		Addr:              config.addr,
 		StreamLargeBodies: 1024 * 1024 * 5,
+		SslInsecure:       config.ssl_insecure,
 	}
 
 	p, err := proxy.NewProxy(opts)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,6 +18,7 @@ var log = _log.WithField("at", "proxy")
 type Options struct {
 	Addr              string
 	StreamLargeBodies int64
+	SslInsecure       bool
 }
 
 type Proxy struct {
@@ -51,6 +52,7 @@ func NewProxy(opts *Options) (*Proxy, error) {
 			ForceAttemptHTTP2:     false, // disable http2
 			DisableCompression:    true,  // To get the original response from the server, set Transport.DisableCompression to true.
 			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: opts.SslInsecure,
 				KeyLogWriter: GetTlsKeyLogWriter(),
 			},
 		},


### PR DESCRIPTION
the flag of -insecure is a way to disable SSL check when client connects to remote sites

see also https://docs.mitmproxy.org/stable/concepts-options/ and the same option about `ssl_insecure`