### PR TITLE
Upstream proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
-replace github.com/lqqyt2423/go-mitmproxy/v1.3.1 => github.com/t1nky/go-mitmproxy main
+replace github.com/lqqyt2423/go-mitmproxy => ./go-mitmproxy

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,3 @@ require (
 	golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
-
-replace github.com/lqqyt2423/go-mitmproxy => ./go-mitmproxy

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
+
+replace github.com/lqqyt2423/go-mitmproxy/v1.3.1 => github.com/t1nky/go-mitmproxy main

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -105,10 +105,17 @@ func (connCtx *ConnContext) initHttpServerConn() {
 		return
 	}
 
+	var useProxy func(*http.Request) (*url.URL, error)
+	if len(connCtx.proxy.Opts.Upstream) > 0 {
+		upstreamUrl, _ := url.Parse(connCtx.proxy.Opts.Upstream)
+		useProxy = http.ProxyURL(upstreamUrl)
+	} else {
+		useProxy = http.ProxyFromEnvironment
+	}
 	serverConn := newServerConn()
 	serverConn.client = &http.Client{
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
+			Proxy: useProxy,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				c, err := (&net.Dialer{}).DialContext(ctx, network, addr)
 				if err != nil {

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -209,6 +209,7 @@ func getProxyConn(proxyUrl *url.URL, address string) (net.Conn, error) {
 		Method: "CONNECT",
 		URL:    &url.URL{Opaque: address},
 		Host:   address,
+		Header: http.Header{},
 	}
 	if proxyUrl.User != nil {
 		connectReq.Header.Set("Proxy-Authorization", "Basic"+base64.StdEncoding.EncodeToString([]byte(proxyUrl.User.String())))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -16,6 +16,7 @@ type Options struct {
 	StreamLargeBodies int64 // 当请求或响应体大于此字节时，转为 stream 模式
 	SslInsecure       bool
 	CaRootPath        string
+	Upstream          string
 }
 
 type Proxy struct {


### PR DESCRIPTION
Added upstream proxy option +authentication support
Tested, working correctly

--
Not sure if we need auth in the `initHttpServerConn` as well. Do we even need to set up a proxy there at all, should Transport.Proxy be removed completely?