### PR TITLE
Implement Basic Authentication for proxy server

### DIFF
--- a/examples/proxy-auth/main.go
+++ b/examples/proxy-auth/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"github.com/lqqyt2423/go-mitmproxy/proxy"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
+)
+
+type UserAuth struct {
+	Username string
+	Password string
+}
+
+// AuthEntrypAuth handles the proxy authentication for the entry point.
+func (user *UserAuth) AuthEntrypAuth(res http.ResponseWriter, req *http.Request) (bool, error) {
+	get := req.Header.Get("Proxy-Authorization")
+	if get == "" {
+		return false, errors.New("empty auth")
+	}
+	auth := user.parseRequestAuth(get)
+	if !auth {
+		return false, errors.New("error auth")
+	}
+	return true, nil
+}
+
+// parseRequestAuth decodes and validates the Proxy-Authorization header.
+func (user *UserAuth) parseRequestAuth(proxyAuth string) bool {
+	if !strings.HasPrefix(proxyAuth, "Basic ") {
+		return false
+	}
+	encodedAuth := strings.TrimPrefix(proxyAuth, "Basic ")
+	decodedAuth, err := base64.StdEncoding.DecodeString(encodedAuth)
+	if err != nil {
+		log.Warnf("Failed to decode Proxy-Authorization header: %v", err)
+		return false
+	}
+
+	n := strings.SplitN(string(decodedAuth), ":", 2)
+	if len(n) < 2 {
+		return false
+	}
+	if user.Username != n[0] || user.Password != n[1] {
+		return false
+	}
+	return true
+}
+
+func main() {
+	opts := &proxy.Options{
+		Addr:              ":9080",
+		StreamLargeBodies: 1024 * 1024 * 5,
+	}
+
+	p, err := proxy.NewProxy(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	auth := &UserAuth{
+		Username: "proxy",
+		Password: "proxy",
+	}
+	// Set up the authentication handler for the proxy.
+	p.SetAuthProxy(auth.AuthEntrypAuth)
+	p.AddAddon(&proxy.LogAddon{})
+
+	log.Fatal(p.Start())
+}

--- a/proxy/attacker.go
+++ b/proxy/attacker.go
@@ -536,7 +536,12 @@ func (a *attacker) attack(res http.ResponseWriter, req *http.Request) {
 	} else {
 		if f.ConnContext.ServerConn == nil && f.ConnContext.dialFn != nil {
 			if err := f.ConnContext.dialFn(req.Context()); err != nil {
+				// Check for authentication failure
 				log.Error(err)
+				if strings.Contains(err.Error(), "Proxy Authentication Required") {
+					httpError(res, "", http.StatusProxyAuthRequired)
+					return
+				}
 				res.WriteHeader(502)
 				return
 			}

--- a/proxy/entry.go
+++ b/proxy/entry.go
@@ -175,6 +175,19 @@ func (e *entry) shutdown(ctx context.Context) error {
 func (e *entry) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	proxy := e.proxy
 
+	log := log.WithFields(log.Fields{
+		"in":   "Proxy.entry.ServeHTTP",
+		"host": req.Host,
+	})
+	// Add entry proxy authentication
+	if e.proxy.authProxy != nil {
+		b, err := e.proxy.authProxy(res, req)
+		if !b {
+			log.Errorf("Proxy authentication failed: %s", err.Error())
+			httpError(res, "", http.StatusProxyAuthRequired)
+			return
+		}
+	}
 	// proxy via connect tunnel
 	if req.Method == "CONNECT" {
 		e.handleConnect(res, req)

--- a/proxy/helper.go
+++ b/proxy/helper.go
@@ -1,8 +1,10 @@
 package proxy
 
 import (
+	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -76,4 +78,11 @@ func transfer(log *log.Entry, server, client io.ReadWriteCloser) {
 			return // 如果有错误，直接返回
 		}
 	}
+}
+
+func httpError(w http.ResponseWriter, error string, code int) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Proxy-Authenticate", `Basic realm="proxy"`) // Indicates that the proxy server requires client credentials
+	w.WriteHeader(code)
+	fmt.Fprintln(w, error)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -32,6 +32,7 @@ type Proxy struct {
 	attacker        *attacker
 	shouldIntercept func(req *http.Request) bool              // req is received by proxy.server
 	upstreamProxy   func(req *http.Request) (*url.URL, error) // req is received by proxy.server, not client request
+	authProxy       func(res http.ResponseWriter, req *http.Request) (bool, error)
 }
 
 // proxy.server req context key
@@ -127,4 +128,8 @@ func (proxy *Proxy) getUpstreamConn(ctx context.Context, req *http.Request) (net
 		conn, err = (&net.Dialer{}).DialContext(ctx, "tcp", address)
 	}
 	return conn, err
+}
+
+func (proxy *Proxy) SetAuthProxy(fn func(res http.ResponseWriter, req *http.Request) (bool, error)) {
+	proxy.authProxy = fn
 }


### PR DESCRIPTION
# 修改目的 (Purpose of Changes):
这些修改的目的是为代理服务器实现 Basic Authentication（基本认证）。通过添加此认证层：

只有具有有效凭据（用户名和密码）的客户端才能访问代理服务。
这确保未经授权的用户无法与代理服务器交互或使用其资源。
这些修改使代理服务器能够通过解码并验证客户端发送的 Proxy-Authorization 头部，安全地进行请求认证。
# 修改效果 (Effect of Changes):
## 认证验证 (Authentication Validation):

客户端必须发送有效的 Proxy-Authorization 头部，包含格式为 Basic <base64编码的用户名:密码> 的凭据。

## 错误响应 (Error Responses):

如果认证失败（例如，凭据无效或缺失），代理服务器将响应 Proxy Authentication Required 错误（HTTP 状态码 407）。

这将防止任何未经授权的访问代理服务。
## 日志记录 (Logging):

如果解码 Proxy-Authorization 头部失败，代理将记录警告信息，提供有关认证错误的详细信息。

## 代理设置 (Proxy Setup):

代理服务器已配置为使用认证处理程序，确保只有授权的客户端才能使用代理服务。

## 合并请求检查清单 (Merge Request Checklist):
- [x] 功能实现：已实现 Basic Authentication 机制，验证客户端的 Proxy-Authorization 头部。
- [x] 认证失败处理：对于无效或缺失的认证凭据，代理返回 HTTP 状态码 407。
- [x] 日志记录：认证失败时有适当的警告日志输出，帮助调试和跟踪问题。
- [x] 代码清晰：所有方法和功能命名清晰，易于理解。
- [x]  测试：已经在本地或测试环境中验证了认证功能的正常工作。
- [x] 文档：提交了简洁的合并请求文档，概述了修改的目的和效果。
- [x] 兼容性：修改不影响代理服务的其他功能，并确保与现有的代理架构兼容。

# 测试
go build -o ./bin/ ./examples/...
./bin/proxy_auth

日志输出

curl -x proxy:error@127.0.0.1:9080 https://httpbin.org/get -k -v
curl -x proxy:proxy@127.0.0.1:9080 https://httpbin.org/get -k -v

```
time="2025-02-18T14:49:07+08:00" level=info msg="Proxy start listen at :9080\n"
time="2025-02-18T14:49:11+08:00" level=info msg="127.0.0.1:64115 client connect\n"
time="2025-02-18T14:49:11+08:00" level=error msg="entry proxy auth fail error auth" host="httpbin.org:443" in=Proxy.entry.ServeHTTP
time="2025-02-18T14:49:11+08:00" level=info msg="127.0.0.1:64115 client disconnect\n"
time="2025-02-18T14:49:18+08:00" level=info msg="127.0.0.1:64149 client connect\n"
time="2025-02-18T14:49:18+08:00" level=info msg="127.0.0.1:64149 server connect httpbin.org:443 (172.19.90.132:64150->3.83.211.175:443)\n"
time="2025-02-18T14:49:19+08:00" level=info msg="127.0.0.1:64149 CONNECT //httpbin.org:443 200 0 - 1011 ms\n"
time="2025-02-18T14:49:19+08:00" level=info msg="127.0.0.1:64149 GET https://httpbin.org/get 200 256 - 275 ms\n"
time="2025-02-18T14:49:19+08:00" level=info msg="127.0.0.1:64149 client disconnect\n"
time="2025-02-18T14:49:19+08:00" level=info msg="127.0.0.1:64149 server disconnect httpbin.org:443 (172.19.90.132:64150->3.83.211.175:443) - 1\n"

```

