### PR TITLE
Add -proxy_auth authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Usage of go-mitmproxy:
     	map local config filename
   -map_remote string
     	map remote config filename
+  -proxyauth string
+        enable proxy authentication. Format: "username:pass", "user1:pass1|user2:pass2","any" to accept any user/pass combination
   -ssl_insecure
     	not verify upstream server SSL/TLS certificates.
   -upstream string

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,6 +66,8 @@ Usage of go-mitmproxy:
     	map local json配置文件地址
   -map_remote string
     	map remote json配置文件地址
+  -proxyauth string
+        启用代理认证。格式："user:pass"、"user1:pass1|user2:pass2"，或使用 "any" 允许所有用户
   -ssl_insecure
     	不验证上游服务器的 SSL/TLS 证书
   -upstream string

--- a/cmd/go-mitmproxy/config.go
+++ b/cmd/go-mitmproxy/config.go
@@ -35,7 +35,7 @@ func loadConfigFromCli() *Config {
 	flag.StringVar(&config.MapLocal, "map_local", "", "map local config filename")
 	flag.StringVar(&config.filename, "f", "", "read config from the filename")
 
-	flag.StringVar(&config.ProxyAuth, "proxyauth", "", `Require proxy authentication. Format: "username:pass", "user1:pass1|user2:pass2","any" to accept any user/pass combination`)
+	flag.StringVar(&config.ProxyAuth, "proxyauth", "", `enable proxy authentication. Format: "username:pass", "user1:pass1|user2:pass2","any" to accept any user/pass combination`)
 	flag.Parse()
 
 	return config

--- a/cmd/go-mitmproxy/config.go
+++ b/cmd/go-mitmproxy/config.go
@@ -34,6 +34,8 @@ func loadConfigFromCli() *Config {
 	flag.StringVar(&config.MapRemote, "map_remote", "", "map remote config filename")
 	flag.StringVar(&config.MapLocal, "map_local", "", "map local config filename")
 	flag.StringVar(&config.filename, "f", "", "read config from the filename")
+
+	flag.StringVar(&config.ProxyAuth, "proxyauth", "", `Require proxy authentication. Format: "username:pass", "user1:pass1|user2:pass2","any" to accept any user/pass combination`)
 	flag.Parse()
 
 	return config

--- a/cmd/go-mitmproxy/main.go
+++ b/cmd/go-mitmproxy/main.go
@@ -5,6 +5,7 @@ import (
 	rawLog "log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/lqqyt2423/go-mitmproxy/addon"
 	"github.com/lqqyt2423/go-mitmproxy/internal/helper"
@@ -31,6 +32,9 @@ type Config struct {
 	MapLocal     string   // map local config filename
 
 	filename string // read config from the filename
+
+	ProxyAuth string // Require proxy authentication
+
 }
 
 func main() {
@@ -85,6 +89,12 @@ func main() {
 	if !config.UpstreamCert {
 		p.AddAddon(proxy.NewUpstreamCertAddon(false))
 		log.Infoln("UpstreamCert config false")
+	}
+
+	if config.ProxyAuth != "" && strings.ToLower(config.ProxyAuth) != "any" {
+		log.Infoln("Enable entry authentication")
+		auth := NewDefaultBasicAuth(config.ProxyAuth)
+		p.SetAuthProxy(auth.EntryAuth)
 	}
 
 	p.AddAddon(&proxy.LogAddon{})

--- a/cmd/go-mitmproxy/utils.go
+++ b/cmd/go-mitmproxy/utils.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
+)
+
+type DefaultBasicAuth struct {
+	Auth map[string]string
+}
+
+// Create a new BasicAuth instance from a user:password string
+func NewDefaultBasicAuth(auth string) *DefaultBasicAuth {
+	basicAuth := &DefaultBasicAuth{
+		Auth: make(map[string]string),
+	}
+	for _, e := range strings.Split(auth, "|") {
+		n := strings.SplitN(e, ":", 2)
+		if len(n) != 2 {
+			log.Fatalf("Invalid proxy auth format: %s, expected user:pass", e)
+		}
+		basicAuth.Auth[n[0]] = n[1]
+	}
+	return basicAuth
+}
+
+// Validate proxy authentication
+func (auth *DefaultBasicAuth) EntryAuth(res http.ResponseWriter, req *http.Request) (bool, error) {
+	get := req.Header.Get("Proxy-Authorization")
+	if get == "" {
+		return false, errors.New("missing authentication")
+	}
+	ret := auth.parseRequestAuth(get)
+	if !ret {
+		return false, errors.New("invalid credentials")
+	}
+	return true, nil
+}
+
+// Parse and verify the Proxy-Authorization header
+func (user *DefaultBasicAuth) parseRequestAuth(proxyAuth string) bool {
+	if !strings.HasPrefix(proxyAuth, "Basic ") {
+		return false
+	}
+	encodedAuth := strings.TrimPrefix(proxyAuth, "Basic ")
+	decodedAuth, err := base64.StdEncoding.DecodeString(encodedAuth)
+	if err != nil {
+		log.Warnf("Failed to decode Proxy-Authorization header: %v", err)
+		return false
+	}
+
+	n := strings.SplitN(string(decodedAuth), ":", 2)
+	if len(n) < 2 {
+		return false
+	}
+	if s, ok := user.Auth[n[0]]; !ok || s != n[1] {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
# 修改目的 (Purpose of Changes):
为go-mitmproxy提供-proxyauth支持，功能符合 https://docs.mitmproxy.org/stable/concepts-options/#proxyauth

支持 
```
"user:pass"（单个用户认证）
"user1:pass1|user2:pass2"（多个用户认证）
"any"（允许所有用户）
```

# 修改效果 (Effect of Changes):
## 认证验证 (Authentication Validation):

在启用-proxyauth选项后，客户端必须携带身份认证信息才可进行数据访问。否则相应Proxy Authentication Required 错误（HTTP 状态码 407）

## 错误响应 (Error Responses):

如果认证失败（例如，凭据无效或缺失），代理服务器将响应 Proxy Authentication Required 错误（HTTP 状态码 407）。

这将防止任何未经授权的访问代理服务。
## 日志记录 (Logging):

如果解码 Proxy-Authorization 头部失败，代理将记录警告信息，提供有关认证错误的详细信息。

## 代理设置 (Proxy Setup):

代理服务器已配置为使用认证处理程序，确保只有授权的客户端才能使用代理服务。

## 合并请求检查清单 (Merge Request Checklist):
- [x] 功能实现：已实现-proxyauth参数功能
- [x] 认证失败处理：对于无效或缺失的认证凭据，代理返回 HTTP 状态码 407。
- [x] 日志记录：认证失败时有适当的警告日志输出，帮助调试和跟踪问题。
- [x] 代码清晰：所有方法和功能命名清晰，易于理解。
- [x]  测试：已经在本地或测试环境中验证了认证功能的正常工作。
- [x] 文档：提交了简洁的合并请求文档，概述了修改的目的和效果。
- [x] 兼容性：修改不影响代理服务的其他功能，并确保与现有的代理架构兼容。

# 测试
```
go build -o ./bin/ ./cmd/...
// 单个用户
./bin/go-mitmproxy -proxyauth proxy:proxy 
// 多个用户
./bin/go-mitmproxy -proxyauth "user1:pass1|user2:pass2"
```

日志输出

```
curl -x proxy:error@127.0.0.1:9080 https://httpbin.org/get -k -v
curl -x proxy:proxy@127.0.0.1:9080 https://httpbin.org/get -k -v
curl -x 127.0.0.1:9080 https://httpbin.org/get -k -v
```

```
time="2025-02-19T17:52:51+08:00" level=info msg="go-mitmproxy version 1.8.5\n"
time="2025-02-19T17:52:51+08:00" level=info msg="Enable entry authentication"
time="2025-02-19T17:52:51+08:00" level=info msg="web interface start listen at :9081\n"
time="2025-02-19T17:52:51+08:00" level=info msg="Proxy start listen at :9080\n"
time="2025-02-19T17:53:12+08:00" level=info msg="127.0.0.1:49539 client connect\n"
time="2025-02-19T17:53:12+08:00" level=error msg="Proxy authentication failed: invalid credentials" host="httpbin.org:443" in=Proxy.entry.ServeHTTP
time="2025-02-19T17:53:12+08:00" level=info msg="127.0.0.1:49539 client disconnect\n"
time="2025-02-19T17:53:18+08:00" level=info msg="127.0.0.1:49546 client connect\n"
time="2025-02-19T17:53:19+08:00" level=info msg="127.0.0.1:49546 server connect httpbin.org:443 (172.19.90.132:49547->52.22.198.150:443)\n"
time="2025-02-19T17:53:19+08:00" level=info msg="127.0.0.1:49546 CONNECT //httpbin.org:443 200 0 - 1032 ms\n"
time="2025-02-19T17:53:20+08:00" level=info msg="127.0.0.1:49546 GET https://httpbin.org/get 200 256 - 610 ms\n"
time="2025-02-19T17:53:20+08:00" level=info msg="127.0.0.1:49546 client disconnect\n"
time="2025-02-19T17:53:20+08:00" level=info msg="127.0.0.1:49546 server disconnect httpbin.org:443 (172.19.90.132:49547->52.22.198.150:443) - 1\n"
time="2025-02-19T17:53:31+08:00" level=info msg="127.0.0.1:49562 client connect\n"
time="2025-02-19T17:53:31+08:00" level=error msg="Proxy authentication failed: missing authentication" host="httpbin.org:443" in=Proxy.entry.ServeHTTP
time="2025-02-19T17:53:31+08:00" level=info msg="127.0.0.1:49562 client disconnect\n"

```

