### PR TITLE
fix: WebSocket 代理握手失败 - 转发客户端请求头到上游服务器

### DIFF
--- a/proxy/websocket.go
+++ b/proxy/websocket.go
@@ -84,9 +84,14 @@ func (h *webSocketHandler) handle(serverConn, clientConn net.Conn, f *Flow) erro
 	serverURL := "ws://" + clientReq.Host + clientReq.URL.RequestURI()
 	log.Debugf("Connecting to server: %s", serverURL)
 
-	// Dialer 会自动添加所有必需的 WebSocket 握手头
-	// 我们不传递 clientReq.Header，避免重复头的错误
-	serverWS, _, err := dialer.Dial(serverURL, nil)
+	// 转发客户端的请求头（Cookie、Origin 等），但排除 WebSocket 握手专用头
+	// gorilla/websocket Dialer 会自动生成 Upgrade、Connection、Sec-WebSocket-* 等握手头
+	forwardHeaders := filterWebSocketHeaders(clientReq.Header)
+	if protocols := clientReq.Header.Get("Sec-WebSocket-Protocol"); protocols != "" {
+		dialer.Subprotocols = websocket.Subprotocols(clientReq)
+	}
+
+	serverWS, _, err := dialer.Dial(serverURL, forwardHeaders)
 	if err != nil {
 		log.Errorf("Failed to dial server: %v", err)
 		return err
@@ -250,9 +255,14 @@ func (h *webSocketHandler) handleWSS(res http.ResponseWriter, req *http.Request)
 		},
 	}
 
-	// Dialer 会自动添加所有必需的 WebSocket 握手头
-	// 我们不传递 req.Header，避免重复头的错误
-	serverWS, _, err := dialer.Dial(serverURL, nil)
+	// 转发客户端的请求头（Cookie、Origin 等），但排除 WebSocket 握手专用头
+	// gorilla/websocket Dialer 会自动生成 Upgrade、Connection、Sec-WebSocket-* 等握手头
+	forwardHeaders := filterWebSocketHeaders(req.Header)
+	if protocols := req.Header.Get("Sec-WebSocket-Protocol"); protocols != "" {
+		dialer.Subprotocols = websocket.Subprotocols(req)
+	}
+
+	serverWS, _, err := dialer.Dial(serverURL, forwardHeaders)
 	if err != nil {
 		log.Errorf("Failed to dial WSS server: %v", err)
 		return err
@@ -289,4 +299,24 @@ func (h *webSocketHandler) handleWSS(res http.ResponseWriter, req *http.Request)
 
 	// 双向转发消息
 	return h.forwardMessages(clientWS, serverWS, f)
+}
+
+// filterWebSocketHeaders 从客户端请求头中提取需要转发给上游服务器的头
+// 排除 WebSocket 握手专用头（gorilla/websocket Dialer 会自动生成这些头）
+func filterWebSocketHeaders(src http.Header) http.Header {
+	skipHeaders := map[string]bool{
+		"Upgrade":                  true,
+		"Connection":               true,
+		"Sec-Websocket-Key":        true,
+		"Sec-Websocket-Version":    true,
+		"Sec-Websocket-Extensions": true,
+		"Sec-Websocket-Protocol":   true,
+	}
+	dst := http.Header{}
+	for key, values := range src {
+		if !skipHeaders[http.CanonicalHeaderKey(key)] {
+			dst[key] = values
+		}
+	}
+	return dst
 }


### PR DESCRIPTION
## 问题

  WebSocket (WS/WSS) 代理在向上游服务器发起握手时，`dialer.Dial(serverURL, nil)` 传入了 `nil` header，
  导致客户端的 Cookie、Origin、User-Agent 等请求头没有转发给服务器。

  很多 WebSocket 服务器会在握手阶段校验这些头（如会话认证、跨域检查），缺失后直接拒绝连接，
  产生大量 `websocket: bad handshake` 错误。

  ## 修复

  - 从客户端请求头中提取非握手头（Cookie、Origin、User-Agent、Authorization 等）转发给上游服务器
  - 排除 WebSocket 握手专用头（Upgrade、Connection、Sec-WebSocket-*），避免与 gorilla/websocket Dialer
  自动生成的头冲突
  - 正确传递 Sec-WebSocket-Protocol 子协议协商
  - 同时修复 `handle()`（WS）和 `handleWSS()`（WSS）两条代码路径

  ## 改动文件

  - `proxy/websocket.go`：新增 `filterWebSocketHeaders()` 函数，修改 `handle()` 和 `handleWSS()` 的 Dial 调用