### PR TITLE
forward request headers to upstream on WebSocket upgrade

### DIFF
--- a/proxy/websocket.go
+++ b/proxy/websocket.go
@@ -6,10 +6,36 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 )
+
+var wsHandshakeHeaders = map[string]struct{}{
+	"Upgrade":                  {},
+	"Connection":               {},
+	"Sec-Websocket-Key":        {},
+	"Sec-Websocket-Version":    {},
+	"Sec-Websocket-Extensions": {},
+	"Sec-Websocket-Protocol":   {},
+}
+
+func cloneHeaderWithoutWSHandshake(h http.Header) http.Header {
+	out := make(http.Header, len(h))
+	for k, vals := range h {
+		if _, skip := wsHandshakeHeaders[http.CanonicalHeaderKey(k)]; skip {
+			continue
+		}
+		if strings.EqualFold(k, "Host") {
+			continue
+		}
+		cloned := make([]string, len(vals))
+		copy(cloned, vals)
+		out[k] = cloned
+	}
+	return out
+}
 
 type webSocketHandler struct {
 	proxy *Proxy
@@ -250,9 +276,8 @@ func (h *webSocketHandler) handleWSS(res http.ResponseWriter, req *http.Request)
 		},
 	}
 
-	// Dialer 会自动添加所有必需的 WebSocket 握手头
-	// 我们不传递 req.Header，避免重复头的错误
-	serverWS, _, err := dialer.Dial(serverURL, nil)
+	upstreamHeader := cloneHeaderWithoutWSHandshake(req.Header)
+	serverWS, _, err := dialer.Dial(serverURL, upstreamHeader)
 	if err != nil {
 		log.Errorf("Failed to dial WSS server: %v", err)
 		return err


### PR DESCRIPTION
## Problem

When a client opens a WebSocket connection through the proxy, addons can modify the request in the `Requestheaders` callback, but the modified headers never reach the upstream server. `handleWSS` at `websocket.go:255` passes `nil` headers to the gorilla/websocket Dialer, so any addon-injected headers (Authorization, API keys, custom tracing headers, etc.) are dropped.

The comment on that line explains the reason for passing `nil`: the gorilla Dialer regenerates the WebSocket handshake headers itself, and forwarding them from the client request causes duplicate-header errors.

## Fix

Strip only the WebSocket handshake headers the Dialer regenerates (`Upgrade`, `Connection`, `Sec-Websocket-*`, `Host`) and forward the rest of `req.Header` to the upstream dial. Addon-modified custom headers now reach the upstream WS server.