### PR TITLE
Fix HTTP/2 RST_STREAM scheduler crash

### DIFF
--- a/proxy/attacker.go
+++ b/proxy/attacker.go
@@ -82,12 +82,6 @@ func newAttacker(proxy *Proxy) (*attacker, error) {
 
 	a.h2Server = &http2.Server{
 		MaxConcurrentStreams: 100, // todo: wait for remote server setting
-		NewWriteScheduler: func() http2.WriteScheduler {
-			return http2.NewPriorityWriteScheduler(&http2.PriorityWriteSchedulerConfig{
-				MaxClosedNodesInTree: 0,
-				MaxIdleNodesInTree:   10,
-			})
-		},
 	}
 
 	return a, nil

--- a/proxy/attacker.go
+++ b/proxy/attacker.go
@@ -82,7 +82,12 @@ func newAttacker(proxy *Proxy) (*attacker, error) {
 
 	a.h2Server = &http2.Server{
 		MaxConcurrentStreams: 100, // todo: wait for remote server setting
-		NewWriteScheduler:    func() http2.WriteScheduler { return http2.NewPriorityWriteScheduler(nil) },
+		NewWriteScheduler: func() http2.WriteScheduler {
+			return http2.NewPriorityWriteScheduler(&http2.PriorityWriteSchedulerConfig{
+				MaxClosedNodesInTree: 0,
+				MaxIdleNodesInTree:   10,
+			})
+		},
 	}
 
 	return a, nil

--- a/proxy/attacker_http2_test.go
+++ b/proxy/attacker_http2_test.go
@@ -1,0 +1,180 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/lqqyt2423/go-mitmproxy/cert"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func TestAttackerHTTP2RSTStreamAfterQueuedResponseDoesNotPanic(t *testing.T) {
+	proxy, err := NewProxy(&Options{NewCaFunc: cert.NewSelfSignCAMemory})
+	handleError(t, err)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	serverDone := make(chan struct{})
+	body := bytes.Repeat([]byte("a"), 256*1024)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	})
+	go func() {
+		defer close(serverDone)
+		proxy.attacker.h2Server.ServeConn(serverConn, &http2.ServeConnOpts{
+			Handler:    handler,
+			BaseConfig: proxy.attacker.server,
+		})
+	}()
+	defer func() {
+		serverConn.Close()
+		select {
+		case <-serverDone:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for HTTP/2 server connection to close")
+		}
+	}()
+
+	fr := http2.NewFramer(clientConn, clientConn)
+	writeHTTP2Request(t, clientConn, fr)
+	readResponseHeaders(t, clientConn, fr, 1)
+
+	dataHeader := readNextDataFrameHeader(t, clientConn, 1)
+
+	pingData := [8]byte{'r', 's', 't', '-', 'p', 'i', 'n', 'g'}
+	setWriteDeadline(t, clientConn)
+	if err := fr.WriteRSTStream(1, http2.ErrCodeCancel); err != nil {
+		t.Fatal(err)
+	}
+	if err := fr.WritePing(false, pingData); err != nil {
+		t.Fatal(err)
+	}
+
+	setReadDeadline(t, clientConn)
+	if _, err := io.CopyN(io.Discard, clientConn, int64(dataHeader.Length)); err != nil {
+		t.Fatal(err)
+	}
+
+	readPingAck(t, clientConn, fr, pingData)
+}
+
+func writeHTTP2Request(t *testing.T, conn net.Conn, fr *http2.Framer) {
+	t.Helper()
+
+	setWriteDeadline(t, conn)
+	if _, err := conn.Write([]byte(http2.ClientPreface)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fr.WriteSettings(); err != nil {
+		t.Fatal(err)
+	}
+
+	var headerBlock bytes.Buffer
+	enc := hpack.NewEncoder(&headerBlock)
+	for _, hf := range []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":authority", Value: "example.test"},
+		{Name: ":path", Value: "/"},
+	} {
+		if err := enc.WriteField(hf); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := fr.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      1,
+		EndStream:     true,
+		EndHeaders:    true,
+		BlockFragment: headerBlock.Bytes(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readResponseHeaders(t *testing.T, conn net.Conn, fr *http2.Framer, streamID uint32) {
+	t.Helper()
+
+	for {
+		f := readFrame(t, conn, fr)
+		switch f := f.(type) {
+		case *http2.SettingsFrame:
+			if !f.IsAck() {
+				setWriteDeadline(t, conn)
+				if err := fr.WriteSettingsAck(); err != nil {
+					t.Fatal(err)
+				}
+			}
+		case *http2.HeadersFrame:
+			if f.Header().StreamID == streamID {
+				return
+			}
+		}
+	}
+}
+
+func readNextDataFrameHeader(t *testing.T, conn net.Conn, streamID uint32) http2.FrameHeader {
+	t.Helper()
+
+	for {
+		setReadDeadline(t, conn)
+		fh, err := http2.ReadFrameHeader(conn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fh.Type == http2.FrameData && fh.StreamID == streamID {
+			return fh
+		}
+		setReadDeadline(t, conn)
+		if _, err := io.CopyN(io.Discard, conn, int64(fh.Length)); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func readPingAck(t *testing.T, conn net.Conn, fr *http2.Framer, want [8]byte) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f := readFrame(t, conn, fr)
+		ping, ok := f.(*http2.PingFrame)
+		if ok && ping.IsAck() && ping.Data == want {
+			return
+		}
+	}
+	t.Fatal("timed out waiting for PING ack")
+}
+
+func readFrame(t *testing.T, conn net.Conn, fr *http2.Framer) http2.Frame {
+	t.Helper()
+
+	setReadDeadline(t, conn)
+	f, err := fr.ReadFrame()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func setReadDeadline(t *testing.T, conn net.Conn) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setWriteDeadline(t *testing.T, conn net.Conn) {
+	t.Helper()
+	if err := conn.SetWriteDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- configure the HTTP/2 priority scheduler to avoid retaining closed stream nodes
- add a regression that queues a large response, sends RST_STREAM, then sends PING on the same connection

## Details
With the default RFC 7540 priority scheduler, closed stream nodes are retained. If a client resets a stream after a large response has queued DATA frames, the retained closed node can keep stale queue state. A later server write, such as a PING ACK or another scheduled frame, can pop a zero FrameWriteRequest and panic inside x/net/http2.

Stack trace shape:
```
panic: runtime error: invalid memory address or nil pointer dereference
golang.org/x/net/http2.(*serverConn).startFrameWrite(..., {{0x0, 0x0}, 0x0, 0x0})
golang.org/x/net/http2.(*serverConn).scheduleFrameWrite
golang.org/x/net/http2.(*serverConn).wroteFrame
```

The test reproduces the RST_STREAM-after-queued-response sequence using the proxy attacker HTTP/2 server. It panics with `NewPriorityWriteScheduler(nil)` and passes when closed stream retention is disabled with `MaxClosedNodesInTree: 0`.

## Tests
- `go test ./...`
- `go test ./proxy -run TestAttackerHTTP2RSTStreamAfterQueuedResponseDoesNotPanic -count=30`