### PR TITLE
添加 https proxy 的支持，可以对外部暴露 https proxy端口

### DIFF
--- a/cmd/go-mitmproxy/config.go
+++ b/cmd/go-mitmproxy/config.go
@@ -22,6 +22,7 @@ func loadConfigFromCli() *Config {
 	flag.BoolVar(&config.version, "version", false, "show go-mitmproxy version")
 	flag.StringVar(&config.Addr, "addr", ":9080", "proxy listen addr")
 	flag.StringVar(&config.HTTPSAddr, "https_addr", "", "https proxy listen addr")
+	flag.BoolVar(&config.WithTLS, "with_tls", false, "run the main proxy listener over TLS (uses https_cert/https_key)")
 	flag.StringVar(&config.HTTPSCert, "https_cert", "", "https proxy server certificate file")
 	flag.StringVar(&config.HTTPSKey, "https_key", "", "https proxy server private key file")
 	flag.StringVar(&config.WebAddr, "web_addr", ":9081", "web interface listen addr")
@@ -53,6 +54,9 @@ func mergeConfigs(fileConfig, cliConfig *Config) *Config {
 	}
 	if cliConfig.HTTPSAddr != "" {
 		config.HTTPSAddr = cliConfig.HTTPSAddr
+	}
+	if cliConfig.WithTLS {
+		config.WithTLS = cliConfig.WithTLS
 	}
 	if cliConfig.HTTPSCert != "" {
 		config.HTTPSCert = cliConfig.HTTPSCert

--- a/cmd/go-mitmproxy/config.go
+++ b/cmd/go-mitmproxy/config.go
@@ -21,6 +21,9 @@ func loadConfigFromCli() *Config {
 
 	flag.BoolVar(&config.version, "version", false, "show go-mitmproxy version")
 	flag.StringVar(&config.Addr, "addr", ":9080", "proxy listen addr")
+	flag.StringVar(&config.HTTPSAddr, "https_addr", "", "https proxy listen addr")
+	flag.StringVar(&config.HTTPSCert, "https_cert", "", "https proxy server certificate file")
+	flag.StringVar(&config.HTTPSKey, "https_key", "", "https proxy server private key file")
 	flag.StringVar(&config.WebAddr, "web_addr", ":9081", "web interface listen addr")
 	flag.BoolVar(&config.SslInsecure, "ssl_insecure", false, "not verify upstream server SSL/TLS certificates.")
 	flag.Var((*arrayValue)(&config.IgnoreHosts), "ignore_hosts", "a list of ignore hosts")
@@ -47,6 +50,15 @@ func mergeConfigs(fileConfig, cliConfig *Config) *Config {
 	*config = *fileConfig
 	if cliConfig.Addr != "" {
 		config.Addr = cliConfig.Addr
+	}
+	if cliConfig.HTTPSAddr != "" {
+		config.HTTPSAddr = cliConfig.HTTPSAddr
+	}
+	if cliConfig.HTTPSCert != "" {
+		config.HTTPSCert = cliConfig.HTTPSCert
+	}
+	if cliConfig.HTTPSKey != "" {
+		config.HTTPSKey = cliConfig.HTTPSKey
 	}
 	if cliConfig.WebAddr != "" {
 		config.WebAddr = cliConfig.WebAddr

--- a/cmd/go-mitmproxy/main.go
+++ b/cmd/go-mitmproxy/main.go
@@ -18,6 +18,9 @@ type Config struct {
 	version bool // show go-mitmproxy version
 
 	Addr         string   // proxy listen addr
+	HTTPSAddr    string   // https proxy listen addr
+	HTTPSCert    string   // https proxy server certificate file
+	HTTPSKey     string   // https proxy server private key file
 	WebAddr      string   // web interface listen addr
 	SslInsecure  bool     // not verify upstream server SSL/TLS certificates.
 	IgnoreHosts  []string // a list of ignore hosts
@@ -58,6 +61,9 @@ func main() {
 	opts := &proxy.Options{
 		Debug:             config.Debug,
 		Addr:              config.Addr,
+		HTTPSAddr:         config.HTTPSAddr,
+		HTTPSCertFile:     config.HTTPSCert,
+		HTTPSKeyFile:      config.HTTPSKey,
 		StreamLargeBodies: 1024 * 1024 * 5,
 		SslInsecure:       config.SslInsecure,
 		CaRootPath:        config.CertPath,

--- a/cmd/go-mitmproxy/main.go
+++ b/cmd/go-mitmproxy/main.go
@@ -19,6 +19,7 @@ type Config struct {
 
 	Addr         string   // proxy listen addr
 	HTTPSAddr    string   // https proxy listen addr
+	WithTLS      bool     // 主代理端口启用 TLS（http over TLS）
 	HTTPSCert    string   // https proxy server certificate file
 	HTTPSKey     string   // https proxy server private key file
 	WebAddr      string   // web interface listen addr
@@ -62,6 +63,7 @@ func main() {
 		Debug:             config.Debug,
 		Addr:              config.Addr,
 		HTTPSAddr:         config.HTTPSAddr,
+		WithTLS:           config.WithTLS,
 		HTTPSCertFile:     config.HTTPSCert,
 		HTTPSKeyFile:      config.HTTPSKey,
 		StreamLargeBodies: 1024 * 1024 * 5,

--- a/proxy/attacker.go
+++ b/proxy/attacker.go
@@ -318,7 +318,7 @@ func (a *attacker) httpsDial(ctx context.Context, req *http.Request) (net.Conn, 
 }
 
 func (a *attacker) httpsTlsDial(ctx context.Context, cconn net.Conn, conn net.Conn) {
-	connCtx := cconn.(*wrapClientConn).connCtx
+	connCtx := clientConnContext(cconn)
 	log := log.WithFields(log.Fields{
 		"in":   "Proxy.attacker.httpsTlsDial",
 		"host": connCtx.ClientConn.Conn.RemoteAddr().String(),
@@ -402,7 +402,7 @@ func (a *attacker) httpsTlsDial(ctx context.Context, cconn net.Conn, conn net.Co
 }
 
 func (a *attacker) httpsLazyAttack(ctx context.Context, cconn net.Conn, req *http.Request) {
-	connCtx := cconn.(*wrapClientConn).connCtx
+	connCtx := clientConnContext(cconn)
 	log := log.WithFields(log.Fields{
 		"in":   "Proxy.attacker.httpsLazyAttack",
 		"host": connCtx.ClientConn.Conn.RemoteAddr().String(),

--- a/proxy/entry.go
+++ b/proxy/entry.go
@@ -194,6 +194,11 @@ func newEntry(proxy *Proxy) *entry {
 			return context.WithValue(ctx, connContextKey, connContextFromClientConn(c))
 		},
 	}
+	if proxy.Opts.WithTLS {
+		e.server.TLSConfig = &tls.Config{
+			NextProtos: []string{"http/1.1"},
+		}
+	}
 	if proxy.Opts.HTTPSAddr != "" {
 		e.httpsServer = &http.Server{
 			Addr:    proxy.Opts.HTTPSAddr,
@@ -216,18 +221,27 @@ func connContextFromClientConn(c net.Conn) *ConnContext {
 	return c.(*wrapClientConn).connCtx
 }
 
+func (e *entry) loadServerCert() (tls.Certificate, error) {
+	if e.proxy.Opts.HTTPSCertFile == "" || e.proxy.Opts.HTTPSKeyFile == "" {
+		return tls.Certificate{}, fmt.Errorf("https proxy requires both cert and key files")
+	}
+	return tls.LoadX509KeyPair(e.proxy.Opts.HTTPSCertFile, e.proxy.Opts.HTTPSKeyFile)
+}
+
 func (e *entry) validateHTTPSConfig() error {
-	if e.httpsServer == nil {
+	if !e.proxy.Opts.WithTLS && e.httpsServer == nil {
 		return nil
 	}
-	if e.proxy.Opts.HTTPSCertFile == "" || e.proxy.Opts.HTTPSKeyFile == "" {
-		return fmt.Errorf("https proxy requires both cert and key files")
-	}
-	cert, err := tls.LoadX509KeyPair(e.proxy.Opts.HTTPSCertFile, e.proxy.Opts.HTTPSKeyFile)
+	cert, err := e.loadServerCert()
 	if err != nil {
 		return err
 	}
-	e.httpsServer.TLSConfig.Certificates = []tls.Certificate{cert}
+	if e.proxy.Opts.WithTLS {
+		e.server.TLSConfig.Certificates = []tls.Certificate{cert}
+	}
+	if e.httpsServer != nil {
+		e.httpsServer.TLSConfig.Certificates = []tls.Certificate{cert}
+	}
 	return nil
 }
 
@@ -235,13 +249,13 @@ func (e *entry) start() error {
 	if e.httpsServer != nil {
 		return e.startHTTPAndHTTPS()
 	}
-	return e.startServer(e.server, false)
+	return e.startServer(e.server, e.proxy.Opts.WithTLS)
 }
 
 func (e *entry) startHTTPAndHTTPS() error {
 	errCh := make(chan error, 2)
 	go func() {
-		errCh <- e.startServer(e.server, false)
+		errCh <- e.startServer(e.server, e.proxy.Opts.WithTLS)
 	}()
 	go func() {
 		errCh <- e.startServer(e.httpsServer, true)
@@ -263,9 +277,12 @@ func (e *entry) startServer(server *http.Server, isHTTPS bool) error {
 		return err
 	}
 
-	if isHTTPS {
+	switch {
+	case server == e.server && isHTTPS:
+		log.Infof("Proxy start listen at %v (over TLS)\n", server.Addr)
+	case isHTTPS:
 		log.Infof("HTTPS proxy start listen at %v\n", server.Addr)
-	} else {
+	default:
 		log.Infof("Proxy start listen at %v\n", server.Addr)
 	}
 	pln := &wrapListener{

--- a/proxy/entry.go
+++ b/proxy/entry.go
@@ -3,6 +3,9 @@ package proxy
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -94,6 +97,49 @@ func (c *wrapClientConn) Close() error {
 	return c.closeErr
 }
 
+type peekableClientConn interface {
+	net.Conn
+	Peek(n int) ([]byte, error)
+	PeekBuffered() ([]byte, error)
+}
+
+type hijackedClientConn struct {
+	net.Conn
+	r       *bufio.Reader
+	connCtx *ConnContext
+}
+
+func newHijackedClientConn(c net.Conn, rw *bufio.ReadWriter, connCtx *ConnContext) *hijackedClientConn {
+	return &hijackedClientConn{
+		Conn:    c,
+		r:       rw.Reader,
+		connCtx: connCtx,
+	}
+}
+
+func (c *hijackedClientConn) Peek(n int) ([]byte, error) {
+	return c.r.Peek(n)
+}
+
+func (c *hijackedClientConn) PeekBuffered() ([]byte, error) {
+	return c.r.Peek(c.r.Buffered())
+}
+
+func (c *hijackedClientConn) Read(data []byte) (int, error) {
+	return c.r.Read(data)
+}
+
+func clientConnContext(c net.Conn) *ConnContext {
+	switch conn := c.(type) {
+	case *wrapClientConn:
+		return conn.connCtx
+	case *hijackedClientConn:
+		return conn.connCtx
+	default:
+		return nil
+	}
+}
+
 // wrap tcpConn for remote server
 type wrapServerConn struct {
 	net.Conn
@@ -134,8 +180,9 @@ func (c *wrapServerConn) Close() error {
 }
 
 type entry struct {
-	proxy  *Proxy
-	server *http.Server
+	proxy       *Proxy
+	server      *http.Server
+	httpsServer *http.Server
 }
 
 func newEntry(proxy *Proxy) *entry {
@@ -144,14 +191,70 @@ func newEntry(proxy *Proxy) *entry {
 		Addr:    proxy.Opts.Addr,
 		Handler: e,
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-			return context.WithValue(ctx, connContextKey, c.(*wrapClientConn).connCtx)
+			return context.WithValue(ctx, connContextKey, connContextFromClientConn(c))
 		},
+	}
+	if proxy.Opts.HTTPSAddr != "" {
+		e.httpsServer = &http.Server{
+			Addr:    proxy.Opts.HTTPSAddr,
+			Handler: e,
+			ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+				return context.WithValue(ctx, connContextKey, connContextFromClientConn(c))
+			},
+			TLSConfig: &tls.Config{
+				NextProtos: []string{"http/1.1"},
+			},
+		}
 	}
 	return e
 }
 
+func connContextFromClientConn(c net.Conn) *ConnContext {
+	if tlsConn, ok := c.(*tls.Conn); ok {
+		c = tlsConn.NetConn()
+	}
+	return c.(*wrapClientConn).connCtx
+}
+
+func (e *entry) validateHTTPSConfig() error {
+	if e.httpsServer == nil {
+		return nil
+	}
+	if e.proxy.Opts.HTTPSCertFile == "" || e.proxy.Opts.HTTPSKeyFile == "" {
+		return fmt.Errorf("https proxy requires both cert and key files")
+	}
+	cert, err := tls.LoadX509KeyPair(e.proxy.Opts.HTTPSCertFile, e.proxy.Opts.HTTPSKeyFile)
+	if err != nil {
+		return err
+	}
+	e.httpsServer.TLSConfig.Certificates = []tls.Certificate{cert}
+	return nil
+}
+
 func (e *entry) start() error {
-	addr := e.server.Addr
+	if e.httpsServer != nil {
+		return e.startHTTPAndHTTPS()
+	}
+	return e.startServer(e.server, false)
+}
+
+func (e *entry) startHTTPAndHTTPS() error {
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- e.startServer(e.server, false)
+	}()
+	go func() {
+		errCh <- e.startServer(e.httpsServer, true)
+	}()
+	err := <-errCh
+	if err != http.ErrServerClosed {
+		e.close()
+	}
+	return err
+}
+
+func (e *entry) startServer(server *http.Server, isHTTPS bool) error {
+	addr := server.Addr
 	if addr == "" {
 		addr = ":http"
 	}
@@ -160,20 +263,33 @@ func (e *entry) start() error {
 		return err
 	}
 
-	log.Infof("Proxy start listen at %v\n", e.server.Addr)
+	if isHTTPS {
+		log.Infof("HTTPS proxy start listen at %v\n", server.Addr)
+	} else {
+		log.Infof("Proxy start listen at %v\n", server.Addr)
+	}
 	pln := &wrapListener{
 		Listener: ln,
 		proxy:    e.proxy,
 	}
-	return e.server.Serve(pln)
+	if isHTTPS {
+		return server.Serve(tls.NewListener(pln, server.TLSConfig))
+	}
+	return server.Serve(pln)
 }
 
 func (e *entry) close() error {
-	return e.server.Close()
+	if e.httpsServer == nil {
+		return e.server.Close()
+	}
+	return errors.Join(e.server.Close(), e.httpsServer.Close())
 }
 
 func (e *entry) shutdown(ctx context.Context) error {
-	return e.server.Shutdown(ctx)
+	if e.httpsServer == nil {
+		return e.server.Shutdown(ctx)
+	}
+	return errors.Join(e.server.Shutdown(ctx), e.httpsServer.Shutdown(ctx))
 }
 
 func (e *entry) ServeHTTP(res http.ResponseWriter, req *http.Request) {
@@ -253,7 +369,7 @@ func (e *entry) handleConnect(res http.ResponseWriter, req *http.Request) {
 }
 
 func (e *entry) establishConnection(res http.ResponseWriter, f *Flow) (net.Conn, error) {
-	cconn, _, err := res.(http.Hijacker).Hijack()
+	cconn, rw, err := res.(http.Hijacker).Hijack()
 	if err != nil {
 		for _, addon := range e.proxy.Addons {
 			addon.HTTPConnectError(f, err)
@@ -280,7 +396,7 @@ func (e *entry) establishConnection(res http.ResponseWriter, f *Flow) (net.Conn,
 		addon.Responseheaders(f)
 	}
 
-	return cconn, nil
+	return newHijackedClientConn(cconn, rw, f.ConnContext), nil
 }
 
 func (e *entry) directTransfer(res http.ResponseWriter, req *http.Request, f *Flow) {
@@ -331,7 +447,8 @@ func (e *entry) httpsDialFirstAttack(res http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	peek, err := cconn.(*wrapClientConn).Peek(3)
+	clientConn := cconn.(peekableClientConn)
+	peek, err := clientConn.Peek(3)
 	if err != nil {
 		cconn.Close()
 		conn.Close()
@@ -345,7 +462,7 @@ func (e *entry) httpsDialFirstAttack(res http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	wsPeek, err := cconn.(*wrapClientConn).PeekBuffered()
+	wsPeek, err := clientConn.PeekBuffered()
 	if err == io.EOF {
 		err = nil
 	}
@@ -384,7 +501,8 @@ func (e *entry) httpsDialLazyAttack(res http.ResponseWriter, req *http.Request, 
 		return
 	}
 
-	peek, err := cconn.(*wrapClientConn).Peek(3)
+	clientConn := cconn.(peekableClientConn)
+	peek, err := clientConn.Peek(3)
 	if err != nil {
 		cconn.Close()
 		log.Error(err)
@@ -397,7 +515,7 @@ func (e *entry) httpsDialLazyAttack(res http.ResponseWriter, req *http.Request, 
 		return
 	}
 
-	wsPeek, err := cconn.(*wrapClientConn).PeekBuffered()
+	wsPeek, err := clientConn.PeekBuffered()
 	if err == io.EOF {
 		err = nil
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -16,6 +16,9 @@ import (
 type Options struct {
 	Debug             int
 	Addr              string
+	HTTPSAddr         string
+	HTTPSCertFile     string
+	HTTPSKeyFile      string
 	StreamLargeBodies int64 // 当请求或响应体大于此字节时，转为 stream 模式
 	SslInsecure       bool
 	CaRootPath        string
@@ -69,6 +72,9 @@ func (proxy *Proxy) AddAddon(addon Addon) {
 }
 
 func (proxy *Proxy) Start() error {
+	if err := proxy.entry.validateHTTPSConfig(); err != nil {
+		return err
+	}
 	go func() {
 		if err := proxy.attacker.start(); err != nil {
 			log.Error(err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,6 +17,7 @@ type Options struct {
 	Debug             int
 	Addr              string
 	HTTPSAddr         string
+	WithTLS           bool // 主代理监听端口 Addr 是否启用 TLS（http over TLS），证书取自 HTTPSCertFile/HTTPSKeyFile
 	HTTPSCertFile     string
 	HTTPSKeyFile      string
 	StreamLargeBodies int64 // 当请求或响应体大于此字节时，转为 stream 模式

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,12 +1,21 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,8 +50,11 @@ func testSendRequest(t *testing.T, endpoint string, client *http.Client, bodyWan
 }
 
 type testProxyHelper struct {
-	server    *http.Server
-	proxyAddr string
+	server         *http.Server
+	proxyAddr      string
+	httpsProxyAddr string
+	httpsCertFile  string
+	httpsKeyFile   string
 
 	ln                     net.Listener
 	tlsPlainLn             net.Listener
@@ -52,6 +64,7 @@ type testProxyHelper struct {
 	testOrderAddonInstance *testOrderAddon
 	testProxy              *Proxy
 	getProxyClient         func() *http.Client
+	getHTTPSProxyClient    func() *http.Client
 }
 
 func (helper *testProxyHelper) init(t *testing.T) {
@@ -90,8 +103,11 @@ func (helper *testProxyHelper) init(t *testing.T) {
 
 	// start proxy
 	testProxy, err := NewProxy(&Options{
-		Addr:        helper.proxyAddr, // some random port
-		SslInsecure: true,
+		Addr:          helper.proxyAddr, // some random port
+		HTTPSAddr:     helper.httpsProxyAddr,
+		HTTPSCertFile: helper.httpsCertFile,
+		HTTPSKeyFile:  helper.httpsKeyFile,
+		SslInsecure:   true,
 	})
 	handleError(t, err)
 	testProxy.AddAddon(&interceptAddon{})
@@ -115,6 +131,61 @@ func (helper *testProxyHelper) init(t *testing.T) {
 		}
 	}
 	helper.getProxyClient = getProxyClient
+
+	getHTTPSProxyClient := func() *http.Client {
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				Proxy: func(r *http.Request) (*url.URL, error) {
+					return url.Parse("https://127.0.0.1" + helper.httpsProxyAddr)
+				},
+			},
+		}
+	}
+	helper.getHTTPSProxyClient = getHTTPSProxyClient
+}
+
+func writeTestTLSCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	handleError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			CommonName: "127.0.0.1",
+		},
+		NotBefore:   time.Now().Add(-time.Hour),
+		NotAfter:    time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	handleError(t, err)
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "server.crt")
+	keyFile := filepath.Join(dir, "server.key")
+
+	certOut, err := os.Create(certFile)
+	handleError(t, err)
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	handleError(t, err)
+	handleError(t, certOut.Close())
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	handleError(t, err)
+	keyOut, err := os.Create(keyFile)
+	handleError(t, err)
+	err = pem.Encode(keyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	handleError(t, err)
+	handleError(t, keyOut.Close())
+
+	return certFile, keyFile
 }
 
 // addon for test intercept
@@ -421,6 +492,78 @@ func TestProxy(t *testing.T) {
 			testOrderAddonInstance.before(t, "ClientDisconnected", "ServerDisconnected")
 		})
 	})
+}
+
+func TestHTTPSProxyEntry(t *testing.T) {
+	certFile, keyFile := writeTestTLSCert(t)
+	helper := &testProxyHelper{
+		server:         &http.Server{},
+		proxyAddr:      ":29107",
+		httpsProxyAddr: ":29108",
+		httpsCertFile:  certFile,
+		httpsKeyFile:   keyFile,
+	}
+	helper.init(t)
+	defer helper.ln.Close()
+	go helper.server.Serve(helper.ln)
+	defer helper.tlsPlainLn.Close()
+	go helper.server.Serve(helper.tlsLn)
+	go helper.testProxy.Start()
+	defer helper.testProxy.Close()
+	time.Sleep(time.Millisecond * 10)
+
+	httpsProxyClient := helper.getHTTPSProxyClient()
+	t.Run("can proxy http over https proxy", func(t *testing.T) {
+		testSendRequest(t, helper.httpEndpoint, httpsProxyClient, "ok")
+	})
+
+	t.Run("can proxy https over https proxy", func(t *testing.T) {
+		testSendRequest(t, helper.httpsEndpoint, httpsProxyClient, "ok")
+	})
+
+	t.Run("force attempt http2 still proxies with http1 outer protocol", func(t *testing.T) {
+		client := helper.getHTTPSProxyClient()
+		client.Transport.(*http.Transport).ForceAttemptHTTP2 = true
+		testSendRequest(t, helper.httpEndpoint, client, "ok")
+
+		conn, err := tls.Dial("tcp", "127.0.0.1"+helper.httpsProxyAddr, &tls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         []string{"h2", "http/1.1"},
+		})
+		handleError(t, err)
+		defer conn.Close()
+		if conn.ConnectionState().NegotiatedProtocol == "h2" {
+			t.Fatal("https proxy entry negotiated h2")
+		}
+
+		req, err := http.NewRequest("GET", helper.httpEndpoint, nil)
+		handleError(t, err)
+		handleError(t, req.WriteProxy(conn))
+		resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+		handleError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		handleError(t, err)
+		if string(body) != "ok" {
+			t.Fatalf("expected ok, but got %s", body)
+		}
+	})
+}
+
+func TestHTTPSProxyEntryRequiresCertAndKey(t *testing.T) {
+	testProxy, err := NewProxy(&Options{
+		Addr:      "127.0.0.1:0",
+		HTTPSAddr: "127.0.0.1:0",
+		NewCaFunc: cert.NewSelfSignCAMemory,
+	})
+	handleError(t, err)
+	err = testProxy.Start()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "requires both cert and key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestProxyWhenServerNotKeepAlive(t *testing.T) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -53,6 +53,7 @@ type testProxyHelper struct {
 	server         *http.Server
 	proxyAddr      string
 	httpsProxyAddr string
+	withTLS        bool
 	httpsCertFile  string
 	httpsKeyFile   string
 
@@ -65,6 +66,7 @@ type testProxyHelper struct {
 	testProxy              *Proxy
 	getProxyClient         func() *http.Client
 	getHTTPSProxyClient    func() *http.Client
+	getWithTLSProxyClient  func() *http.Client
 }
 
 func (helper *testProxyHelper) init(t *testing.T) {
@@ -105,6 +107,7 @@ func (helper *testProxyHelper) init(t *testing.T) {
 	testProxy, err := NewProxy(&Options{
 		Addr:          helper.proxyAddr, // some random port
 		HTTPSAddr:     helper.httpsProxyAddr,
+		WithTLS:       helper.withTLS,
 		HTTPSCertFile: helper.httpsCertFile,
 		HTTPSKeyFile:  helper.httpsKeyFile,
 		SslInsecure:   true,
@@ -145,6 +148,20 @@ func (helper *testProxyHelper) init(t *testing.T) {
 		}
 	}
 	helper.getHTTPSProxyClient = getHTTPSProxyClient
+
+	getWithTLSProxyClient := func() *http.Client {
+		return &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				Proxy: func(r *http.Request) (*url.URL, error) {
+					return url.Parse("https://127.0.0.1" + helper.proxyAddr)
+				},
+			},
+		}
+	}
+	helper.getWithTLSProxyClient = getWithTLSProxyClient
 }
 
 func writeTestTLSCert(t *testing.T) (string, string) {
@@ -554,6 +571,86 @@ func TestHTTPSProxyEntryRequiresCertAndKey(t *testing.T) {
 	testProxy, err := NewProxy(&Options{
 		Addr:      "127.0.0.1:0",
 		HTTPSAddr: "127.0.0.1:0",
+		NewCaFunc: cert.NewSelfSignCAMemory,
+	})
+	handleError(t, err)
+	err = testProxy.Start()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "requires both cert and key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWithTLSProxyEntry(t *testing.T) {
+	certFile, keyFile := writeTestTLSCert(t)
+	helper := &testProxyHelper{
+		server:        &http.Server{},
+		proxyAddr:     ":29109",
+		withTLS:       true,
+		httpsCertFile: certFile,
+		httpsKeyFile:  keyFile,
+	}
+	helper.init(t)
+	defer helper.ln.Close()
+	go helper.server.Serve(helper.ln)
+	defer helper.tlsPlainLn.Close()
+	go helper.server.Serve(helper.tlsLn)
+	go helper.testProxy.Start()
+	defer helper.testProxy.Close()
+	time.Sleep(time.Millisecond * 10)
+
+	withTLSProxyClient := helper.getWithTLSProxyClient()
+	t.Run("can proxy http over tls proxy channel", func(t *testing.T) {
+		testSendRequest(t, helper.httpEndpoint, withTLSProxyClient, "ok")
+	})
+
+	t.Run("can proxy https over tls proxy channel", func(t *testing.T) {
+		testSendRequest(t, helper.httpsEndpoint, withTLSProxyClient, "ok")
+	})
+
+	t.Run("plain http proxy connection fails against tls listener", func(t *testing.T) {
+		plainClient := helper.getProxyClient()
+		_, err := plainClient.Get(helper.httpEndpoint)
+		if err == nil {
+			t.Fatal("expected error when using plain proxy against tls listener")
+		}
+	})
+}
+
+func TestWithTLSCoexistsWithHTTPSAddr(t *testing.T) {
+	certFile, keyFile := writeTestTLSCert(t)
+	helper := &testProxyHelper{
+		server:         &http.Server{},
+		proxyAddr:      ":29110",
+		httpsProxyAddr: ":29111",
+		withTLS:        true,
+		httpsCertFile:  certFile,
+		httpsKeyFile:   keyFile,
+	}
+	helper.init(t)
+	defer helper.ln.Close()
+	go helper.server.Serve(helper.ln)
+	defer helper.tlsPlainLn.Close()
+	go helper.server.Serve(helper.tlsLn)
+	go helper.testProxy.Start()
+	defer helper.testProxy.Close()
+	time.Sleep(time.Millisecond * 10)
+
+	t.Run("main addr is tls", func(t *testing.T) {
+		testSendRequest(t, helper.httpEndpoint, helper.getWithTLSProxyClient(), "ok")
+	})
+
+	t.Run("https_addr port also works", func(t *testing.T) {
+		testSendRequest(t, helper.httpEndpoint, helper.getHTTPSProxyClient(), "ok")
+	})
+}
+
+func TestWithTLSRequiresCertAndKey(t *testing.T) {
+	testProxy, err := NewProxy(&Options{
+		Addr:      "127.0.0.1:0",
+		WithTLS:   true,
 		NewCaFunc: cert.NewSelfSignCAMemory,
 	})
 	handleError(t, err)


### PR DESCRIPTION
使用方法：
```
go-mitmproxy \
    -addr 127.0.0.1:19080 \
    -https_addr 127.0.0.1:19443 \
    -https_cert /private/tmp/go-mitmproxy-https-proxy.crt \
    -https_key /private/tmp/go-mitmproxy-https-proxy.key \
```

代码已经过验证