### PR TITLE
fix: preserve original HTTP/1.1 header name casing on upstream forward

### DIFF
--- a/proxy/attacker.go
+++ b/proxy/attacker.go
@@ -133,7 +133,7 @@ func (a *attacker) serveConn(clientTlsConn *tls.Conn, connCtx *ConnContext) {
 	}
 
 	a.listener.accept(&attackerConn{
-		Conn:    clientTlsConn,
+		Conn:    wrapRawHeaderCapture(clientTlsConn, connCtx),
 		connCtx: connCtx,
 	})
 }
@@ -150,6 +150,9 @@ func (a *attacker) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		f := newFlow()
 		f.Request = newRequest(req)
 		f.ConnContext = req.Context().Value(connContextKey).(*ConnContext)
+		if f.ConnContext != nil {
+			f.Request.RawHeader = f.ConnContext.takeRawRequestHeaders()
+		}
 		f.ConnContext.FlowCount.Add(1)
 
 		for _, addon := range a.proxy.Addons {
@@ -511,6 +514,9 @@ func (a *attacker) attack(res http.ResponseWriter, req *http.Request) {
 	f := newFlow()
 	f.Request = newRequest(req)
 	f.ConnContext = req.Context().Value(connContextKey).(*ConnContext)
+	if f.ConnContext != nil {
+		f.Request.RawHeader = f.ConnContext.takeRawRequestHeaders()
+	}
 	defer f.finish()
 
 	f.ConnContext.FlowCount.Add(1)
@@ -562,22 +568,6 @@ func (a *attacker) attack(res http.ResponseWriter, req *http.Request) {
 		reqBody = addon.StreamRequestModifier(f, reqBody)
 	}
 
-	proxyReqCtx := context.WithValue(req.Context(), proxyReqCtxKey, req)
-	proxyReq, err := http.NewRequestWithContext(proxyReqCtx, f.Request.Method, f.Request.URL.String(), reqBody)
-	if err != nil {
-		for _, addon := range proxy.Addons {
-			addon.RequestError(f, err)
-		}
-		res.WriteHeader(502)
-		return
-	}
-
-	for key, value := range f.Request.Header {
-		for _, v := range value {
-			proxyReq.Header.Add(key, v)
-		}
-	}
-
 	useSeparateClient := f.UseSeparateClient
 	if !useSeparateClient {
 		if rawReqUrlHost != f.Request.URL.Host || rawReqUrlScheme != f.Request.URL.Scheme {
@@ -586,16 +576,18 @@ func (a *attacker) attack(res http.ResponseWriter, req *http.Request) {
 	}
 
 	var proxyRes *http.Response
-	if useSeparateClient {
-		proxyRes, err = a.client.Do(proxyReq)
-	} else {
+	var err error
+
+	// HTTP/1.1 only: write the request ourselves to preserve original header name casing.
+	// Go's http.Transport always emits CanonicalMIMEHeaderKey. HTTP/2 is unchanged.
+	usedRaw := false
+	if !f.Stream && !useSeparateClient {
 		if f.ConnContext.ServerConn == nil && f.ConnContext.dialFn != nil {
-			if err := f.ConnContext.dialFn(req.Context()); err != nil {
+			if dialErr := f.ConnContext.dialFn(req.Context()); dialErr != nil {
 				for _, addon := range proxy.Addons {
-					addon.RequestError(f, err)
+					addon.RequestError(f, dialErr)
 				}
-				// Check for authentication failure
-				if strings.Contains(err.Error(), "Proxy Authentication Required") {
+				if strings.Contains(dialErr.Error(), "Proxy Authentication Required") {
 					httpError(res, "", http.StatusProxyAuthRequired)
 					return
 				}
@@ -603,7 +595,55 @@ func (a *attacker) attack(res http.ResponseWriter, req *http.Request) {
 				return
 			}
 		}
-		proxyRes, err = f.ConnContext.ServerConn.client.Do(proxyReq)
+		sc := f.ConnContext.ServerConn
+		if sc != nil && sc.tlsConn != nil && f.Request.Body != nil && upstreamNegotiatedHTTP11(sc) {
+			reqURI := f.Request.URL.RequestURI()
+			host := f.Request.URL.Host
+			if host == "" {
+				host = req.Host
+			}
+			proxyRes, err = roundTripRawHTTP1(sc.tlsConn, f.Request.Method, reqURI, host, f.Request.Header, f.Request.RawHeader, f.Request.Body)
+			usedRaw = true
+			f.ConnContext.closeAfterResponse = true
+		}
+	}
+
+	if !usedRaw {
+		proxyReqCtx := context.WithValue(req.Context(), proxyReqCtxKey, req)
+		var proxyReq *http.Request
+		proxyReq, err = http.NewRequestWithContext(proxyReqCtx, f.Request.Method, f.Request.URL.String(), reqBody)
+		if err != nil {
+			for _, addon := range proxy.Addons {
+				addon.RequestError(f, err)
+			}
+			res.WriteHeader(502)
+			return
+		}
+
+		for key, value := range f.Request.Header {
+			for _, v := range value {
+				proxyReq.Header.Add(key, v)
+			}
+		}
+
+		if useSeparateClient {
+			proxyRes, err = a.client.Do(proxyReq)
+		} else {
+			if f.ConnContext.ServerConn == nil && f.ConnContext.dialFn != nil {
+				if err = f.ConnContext.dialFn(req.Context()); err != nil {
+					for _, addon := range proxy.Addons {
+						addon.RequestError(f, err)
+					}
+					if strings.Contains(err.Error(), "Proxy Authentication Required") {
+						httpError(res, "", http.StatusProxyAuthRequired)
+						return
+					}
+					res.WriteHeader(502)
+					return
+				}
+			}
+			proxyRes, err = f.ConnContext.ServerConn.client.Do(proxyReq)
+		}
 	}
 	if err != nil {
 		logErr(log, err)

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"sync"
 
 	uuid "github.com/satori/go.uuid"
 	"go.uber.org/atomic"
@@ -84,6 +85,9 @@ type ConnContext struct {
 	proxy              *Proxy
 	closeAfterResponse bool                        // after http response, http server will close the connection
 	dialFn             func(context.Context) error // when begin request, if there no ServerConn, use this func to dial
+
+	rawHeadersMu       sync.Mutex
+	rawRequestHeaders  []RawHeaderField // last HTTP/1.1 request headers as on the wire
 }
 
 func newConnContext(c net.Conn, proxy *Proxy) *ConnContext {

--- a/proxy/entry.go
+++ b/proxy/entry.go
@@ -42,6 +42,7 @@ type wrapClientConn struct {
 	r       *bufio.Reader
 	proxy   *Proxy
 	connCtx *ConnContext
+	splicer http1HeaderSplicer
 
 	closeMu   sync.Mutex
 	closed    bool
@@ -50,12 +51,21 @@ type wrapClientConn struct {
 }
 
 func newWrapClientConn(c net.Conn, proxy *Proxy) *wrapClientConn {
-	return &wrapClientConn{
+	wc := &wrapClientConn{
 		Conn:      c,
 		r:         bufio.NewReader(c),
 		proxy:     proxy,
 		closeChan: make(chan struct{}),
 	}
+	wc.splicer = http1HeaderSplicer{
+		br: wc.r,
+		onCapture: func(fields []RawHeaderField) {
+			if wc.connCtx != nil {
+				wc.connCtx.setRawRequestHeaders(fields)
+			}
+		},
+	}
+	return wc
 }
 
 func (c *wrapClientConn) Peek(n int) ([]byte, error) {
@@ -67,7 +77,7 @@ func (c *wrapClientConn) PeekBuffered() ([]byte, error) {
 }
 
 func (c *wrapClientConn) Read(data []byte) (int, error) {
-	return c.r.Read(data)
+	return c.splicer.Read(data)
 }
 
 func (c *wrapClientConn) Close() error {
@@ -229,6 +239,9 @@ func (e *entry) handleConnect(res http.ResponseWriter, req *http.Request) {
 	f := newFlow()
 	f.Request = newRequest(req)
 	f.ConnContext = req.Context().Value(connContextKey).(*ConnContext)
+	if f.ConnContext != nil {
+		f.Request.RawHeader = f.ConnContext.takeRawRequestHeaders()
+	}
 	f.ConnContext.Intercept = shouldIntercept
 	defer f.finish()
 

--- a/proxy/flow.go
+++ b/proxy/flow.go
@@ -20,6 +20,10 @@ type Request struct {
 	Header http.Header
 	Body   []byte
 
+	// RawHeader is the HTTP/1.1 header block as received (original name casing/order).
+	// Nil for HTTP/2 or when capture was unavailable; then Header (canonical) is used.
+	RawHeader []RawHeaderField
+
 	raw *http.Request
 }
 

--- a/proxy/raw_header_conn.go
+++ b/proxy/raw_header_conn.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+)
+
+// RawHeaderField is one header line exactly as received on the wire (name casing preserved).
+type RawHeaderField struct {
+	Name  string
+	Value string
+}
+
+type http1HeaderSplicer struct {
+	br       *bufio.Reader
+	pending  []byte
+	onCapture func([]RawHeaderField)
+}
+
+func (s *http1HeaderSplicer) Read(p []byte) (int, error) {
+	if len(s.pending) > 0 {
+		n := copy(p, s.pending)
+		s.pending = s.pending[n:]
+		return n, nil
+	}
+
+	peek, err := s.br.Peek(8)
+	if err != nil && len(peek) == 0 {
+		return 0, err
+	}
+	if looksLikeHTTP1Request(peek) {
+		block, err := readHTTP1HeaderBlock(s.br)
+		if err != nil {
+			return 0, err
+		}
+		if s.onCapture != nil {
+			s.onCapture(parseRawHeaderFields(block))
+		}
+		s.pending = block
+		n := copy(p, s.pending)
+		s.pending = s.pending[n:]
+		return n, nil
+	}
+	return s.br.Read(p)
+}
+
+func looksLikeHTTP1Request(peek []byte) bool {
+	methods := []string{
+		"GET ", "POST ", "PUT ", "HEAD ", "DELETE ",
+		"OPTIONS ", "PATCH ", "CONNECT ", "TRACE ",
+	}
+	for _, m := range methods {
+		if len(peek) >= len(m) && string(peek[:len(m)]) == m {
+			return true
+		}
+	}
+	return false
+}
+
+func readHTTP1HeaderBlock(br *bufio.Reader) ([]byte, error) {
+	var buf bytes.Buffer
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			buf.Write(line)
+		}
+		if err != nil {
+			if buf.Len() > 0 {
+				return buf.Bytes(), err
+			}
+			return nil, err
+		}
+		b := buf.Bytes()
+		if bytes.HasSuffix(b, []byte("\r\n\r\n")) || bytes.HasSuffix(b, []byte("\n\n")) {
+			return b, nil
+		}
+		if buf.Len() > 1<<20 {
+			return nil, fmt.Errorf("http header block too large")
+		}
+	}
+}
+
+func parseRawHeaderFields(block []byte) []RawHeaderField {
+	// Split on \n; tolerate \r\n
+	lines := bytes.Split(block, []byte{'\n'})
+	out := make([]RawHeaderField, 0, len(lines))
+	for i, line := range lines {
+		if len(line) > 0 && line[len(line)-1] == '\r' {
+			line = line[:len(line)-1]
+		}
+		if i == 0 {
+			continue // request line
+		}
+		if len(line) == 0 {
+			break
+		}
+		idx := bytes.IndexByte(line, ':')
+		if idx <= 0 {
+			continue
+		}
+		name := string(bytes.TrimSpace(line[:idx]))
+		val := string(bytes.TrimLeft(line[idx+1:], " \t"))
+		if name == "" {
+			continue
+		}
+		out = append(out, RawHeaderField{Name: name, Value: val})
+	}
+	return out
+}
+
+// rawHeaderCaptureConn wraps a conn (e.g. TLS) and records original HTTP/1.1 header names.
+type rawHeaderCaptureConn struct {
+	net.Conn
+	splicer http1HeaderSplicer
+}
+
+func wrapRawHeaderCapture(c net.Conn, connCtx *ConnContext) net.Conn {
+	if c == nil {
+		return nil
+	}
+	if _, ok := c.(*rawHeaderCaptureConn); ok {
+		return c
+	}
+	rc := &rawHeaderCaptureConn{Conn: c}
+	rc.splicer = http1HeaderSplicer{
+		br: bufio.NewReader(c),
+		onCapture: func(fields []RawHeaderField) {
+			if connCtx != nil {
+				connCtx.setRawRequestHeaders(fields)
+			}
+		},
+	}
+	return rc
+}
+
+func (c *rawHeaderCaptureConn) Read(p []byte) (int, error) {
+	return c.splicer.Read(p)
+}
+
+func (c *ConnContext) setRawRequestHeaders(fields []RawHeaderField) {
+	c.rawHeadersMu.Lock()
+	c.rawRequestHeaders = fields
+	c.rawHeadersMu.Unlock()
+}
+
+func (c *ConnContext) takeRawRequestHeaders() []RawHeaderField {
+	c.rawHeadersMu.Lock()
+	h := c.rawRequestHeaders
+	c.rawRequestHeaders = nil
+	c.rawHeadersMu.Unlock()
+	return h
+}

--- a/proxy/raw_roundtrip.go
+++ b/proxy/raw_roundtrip.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// hop-by-hop headers must not be forwarded (RFC 7230).
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailers":            true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+	"Proxy-Connection":    true,
+}
+
+func writeHeaderLine(buf *bytes.Buffer, key, value string) {
+	buf.WriteString(key)
+	buf.WriteString(": ")
+	buf.WriteString(value)
+	buf.WriteString("\r\n")
+}
+
+func hostWithoutDefaultPort(hostport string) string {
+	if h, p, err := net.SplitHostPort(hostport); err == nil {
+		if p == "443" || p == "80" {
+			return h
+		}
+		return hostport
+	}
+	return hostport
+}
+
+// upstreamNegotiatedHTTP11 reports whether the upstream TLS conn speaks HTTP/1.1.
+// Raw forwarding must not run on h2 connections.
+func upstreamNegotiatedHTTP11(sc *ServerConn) bool {
+	if sc == nil || sc.tlsState == nil {
+		return true
+	}
+	p := sc.tlsState.NegotiatedProtocol
+	return p == "" || p == "http/1.1"
+}
+
+func isHopByHop(name string) bool {
+	return hopByHopHeaders[http.CanonicalHeaderKey(name)]
+}
+
+// roundTripRawHTTP1 writes an HTTP/1.1 request with original header names when available.
+func roundTripRawHTTP1(conn net.Conn, method, requestURI, host string, header http.Header, raw []RawHeaderField, body []byte) (*http.Response, error) {
+	if conn == nil {
+		return nil, fmt.Errorf("raw roundtrip: nil conn")
+	}
+	if requestURI == "" {
+		requestURI = "/"
+	}
+	host = hostWithoutDefaultPort(host)
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s %s HTTP/1.1\r\n", method, requestURI)
+	writeHeaderLine(&buf, "Host", host)
+
+	wroteCL := false
+	if len(raw) > 0 {
+		for _, h := range raw {
+			if h.Name == "" || strings.EqualFold(h.Name, "Host") || isHopByHop(h.Name) {
+				continue
+			}
+			if strings.EqualFold(h.Name, "Content-Length") {
+				continue
+			}
+			writeHeaderLine(&buf, h.Name, h.Value)
+		}
+	} else {
+		for key, vals := range header {
+			if key == "Host" || isHopByHop(key) || key == "Content-Length" {
+				continue
+			}
+			for _, v := range vals {
+				writeHeaderLine(&buf, key, v)
+			}
+		}
+	}
+
+	if body != nil {
+		writeHeaderLine(&buf, "Content-Length", fmt.Sprintf("%d", len(body)))
+		wroteCL = true
+	} else if vals := header.Values("Content-Length"); len(vals) > 0 {
+		writeHeaderLine(&buf, "Content-Length", vals[0])
+		wroteCL = true
+	}
+	_ = wroteCL
+
+	writeHeaderLine(&buf, "Connection", "close")
+	buf.WriteString("\r\n")
+
+	if _, err := conn.Write(buf.Bytes()); err != nil {
+		return nil, err
+	}
+	if len(body) > 0 {
+		if _, err := conn.Write(body); err != nil {
+			return nil, err
+		}
+	}
+
+	return http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: method})
+}
+
+// drainAndClose helps callers discard unread response bodies.
+func drainAndClose(body io.ReadCloser) {
+	if body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
+}


### PR DESCRIPTION
Capture header names from the wire before net/http canonicalizes them, and use those names when forwarding buffered HTTPS requests over HTTP/1.1. HTTP/2 negotiation and forwarding are unchanged.